### PR TITLE
Update ICU dependency URL to new artifacts host on GitHub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/deps/meta-cmake/)
 
 FindOrBuildICU(
   VERSION 61.1
-  URL http://download.icu-project.org/files/icu4c/61.1/icu4c-61_1-src.tgz
+  URL https://github.com/unicode-org/icu/releases/download/release-61-1/icu4c-61_1-src.tgz
   URL_HASH MD5=68fe38999fef94d622bd6843d43c0615
 )
 


### PR DESCRIPTION
From the `dmcguire81/metapy` repo, in the `master` branch, except with the submodule `meta` pointing to this branch:

```sh
$ CC=/usr/bin/gcc python setup.py bdist
running bdist
running bdist_dumb
running build
...
-- Generating done
-- Build files have been written to: /private/var/folders/zb/2wfz6fn53_7dndt68ztrd9000000gn/T/tmpac9qjmn0
[  0%] Building CXX object deps/meta/src/util/CMakeFiles/meta-util.dir/progress.cpp.o
...
[100%] Built target metapy
Install the project...
...
byte-compiling build/bdist.macosx-11.6-x86_64/dumb/Users/dmcguire/.pyenv/versions/3.8.11/lib/python3.8/site-packages/metapy/__init__.py to __init__.cpython-38.pyc
running install_egg_info
Copying dist/metapy.egg-info to build/bdist.macosx-11.6-x86_64/dumb/Users/dmcguire/.pyenv/versions/3.8.11/lib/python3.8/site-packages/metapy-0.2.13-py3.8.egg-info
running install_scripts
Creating tar archive
removing 'build/bdist.macosx-11.6-x86_64/dumb' (and everything under it)
```