### PR TITLE
Auto-update base docker image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   docker:
+    if: ${{ !github.event.workflow_run || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,13 +4,18 @@ concurrency:
   group: docker-image-ci
   cancel-in-progress: true
 
-on: push
+on:
+  push:
+  workflow_run:
+    workflows: [ "Docker Base Image CI" ]
+    types:
+      - completed
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
+      - name: Check out the repository
         uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,8 +1,12 @@
 name: Docker Base Image CI
 
+concurrency:
+  group: docker-base-image-ci
+  cancel-in-progress: true
+
 on:
   schedule:
-    - cron: '* * * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   docker:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -2,7 +2,7 @@ name: Docker Base Image CI
 
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '* * * * *'
 
 jobs:
   docker:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,21 @@
+name: Docker Base Image CI
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+      - name: Check for image updates
+        id: check
+        uses: lucacome/docker-image-update-checker@v1
+        with:
+          base-image: library/ubuntu:22.04
+          image: josecols/meta:3.0.2
+      - name: Abort
+        run: exit 1
+        if: steps.check.outputs.needs-updating == 'false'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:22.04
 
 ENV CC=clang-14
 ENV CXX=clang++-14
@@ -6,10 +6,16 @@ ENV PATH=/meta/build:$PATH
 
 COPY . /meta
 
-RUN apt-get update
-RUN apt install -y software-properties-common
-RUN apt-get install -y git cmake libjemalloc-dev zlib1g-dev
-RUN apt-get install -y clang-14 lld-14 libc++-14-dev libc++abi-14-dev
+RUN apt-get update && apt-get install -y \
+    clang-14  \
+    cmake  \
+    git  \
+    libc++-14-dev  \
+    libc++abi-14-dev \
+    libjemalloc-dev  \
+    lld-14  \
+    software-properties-common \
+    zlib1g-dev
 
 WORKDIR /meta
 RUN git submodule update --init --recursive


### PR DESCRIPTION
This PR introduces a new GitHub workflow that checks daily if MeTA's base image (`ubuntu:22.04`) has changes (e.g., security updates). Upon completion, it will trigger the main Docker image build. With this, we are ensuring an up-to-date image version if:
* The MeTA code changes.
* The OS image changes.

One caveat of the new workflow is that the cron scheduler only runs on the default branch. So, we will need to set `submodule/meta` as the main branch or merge all changes to `master`.