### PR TITLE
Fix auto-update base docker image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   docker:
-    if: ${{ !github.event.workflow_run || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ !github.event.workflow_run || github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -22,4 +22,4 @@ jobs:
           image: josecols/meta:3.0.2
       - name: Abort
         run: exit 1
-        if: steps.check.outputs.needs-updating == 'false'
+        if: steps.check.outputs.needs-updating == 'true'


### PR DESCRIPTION
This PR is a follow-up to https://github.com/dmcguire81/meta/pull/3. I am changing the trigger conditions to keep the pipeline status cleaner.

Before:
* Verify base image version -> trigger pipeline error if the image is **up-to-date**.
* Trigger Meta image rebuild if the previous pipeline finished successfully. 

Now:
* Verify base image version -> trigger pipeline error if the image is **outdated**.
* Trigger Meta image rebuild if the previous pipeline failed. 
