### PR TITLE
Add GitHub Container Registry as primary Docker image storage

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,34 +13,45 @@ on:
     types:
       - completed
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   docker:
     if: ${{ !github.event.workflow_run || github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repository
+      -
+        name: Check out the repository
         uses: actions/checkout@v3
-      - name: Set up QEMU
+      -
+        name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64,amd64
-      - name: Set up Docker Buildx
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to GitHub Container Registry
+      -
+        name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      -
+        name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64,linux/amd64
           push: true
-          tags: josecols/meta:3.0.2
+          tags: ${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:3.0.2
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: lucacome/docker-image-update-checker@v1
         with:
           base-image: library/ubuntu:22.04
-          image: josecols/meta:3.0.2
+          image: ghcr.io/illinois/meta:3.0.2
       - name: Abort
         run: exit 1
         if: steps.check.outputs.needs-updating == 'true'

--- a/README.md
+++ b/README.md
@@ -66,16 +66,16 @@ our ACL demo paper:
 # Project setup
 
 ## Docker
-A Docker image with a pre-built version of MeTA is available on [Docker Hub](https://hub.docker.com/r/josecols/meta/tags).
+A Docker image with a pre-built version of MeTA is available on [GitHub Container Registry](https://github.com/illinois/meta/pkgs/container/meta/).
 
 ```bash
-docker pull josecols/meta:3.0.2
+docker pull ghcr.io/illinois/meta:3.0.2
 ```
 
 This docker image makes the MeTA binaries globally available, allowing you to run them from anywhere. For example, to perform [Basic Text Analysis](https://meta-toolkit.org/profile-tutorial.html) on a document, you can create a container from the image and run the following command:
 
 ```bash
-docker run -it --rm --name meta --mount type=bind,source=$(pwd),target=/app --entrypoint bash josecols/meta:3.0.2
+docker run -it --rm --name meta --mount type=bind,source=$(pwd),target=/app --entrypoint bash ghcr.io/illinois/meta:3.0.2
 profile /meta/config.toml doc.txt --stop
 ```
 


### PR DESCRIPTION
I am adding [GitHub Packages](https://github.com/features/packages) support to keep all the artifacts in the same place now that this repository is under the Illinois Open Source project umbrella.

After completing this build, I will follow up with similar changes for `metapy`.